### PR TITLE
Fix compilation for ARM Cortex-M3

### DIFF
--- a/Core/src/CrashCatcherPriv.h
+++ b/Core/src/CrashCatcherPriv.h
@@ -20,6 +20,13 @@
 /* Definitions used by assembly language and C code. */
 #define CRASH_CATCHER_STACK_WORD_COUNT 125
 
+/* Does this device support THUMB instructions for FPU access? */
+#ifdef __ARM_ARCH_7EM__
+#define CRASH_CATCHER_WITH_FPU 1
+#else
+#define CRASH_CATCHER_WITH_FPU 0
+#endif
+
 
 /* Definitions only required from C code. */
 #if !__ASSEMBLER__

--- a/Core/src/CrashCatcher_armv7m.S
+++ b/Core/src/CrashCatcher_armv7m.S
@@ -74,6 +74,7 @@ HardFault_Handler:
     .type CrashCatcher_CopyAllFloatingPointRegisters, %function
     .thumb_func
 CrashCatcher_CopyAllFloatingPointRegisters:
+#if CRASH_CATCHER_WITH_FPU
     // Grab a copy of FPSCR before issuing any other FP instructions.
     vmrs        r1, fpscr
 
@@ -82,7 +83,7 @@ CrashCatcher_CopyAllFloatingPointRegisters:
 
     // Move fpscr to pBuffer.
     str         r1, [r0]
-
+#endif
     // Return to caller.
     bx          lr
 
@@ -100,9 +101,10 @@ CrashCatcher_CopyAllFloatingPointRegisters:
     .type CrashCatcher_CopyUpperFloatingPointRegisters, %function
     .thumb_func
 CrashCatcher_CopyUpperFloatingPointRegisters:
+#if CRASH_CATCHER_WITH_FPU
     // Move s16 - s31 to pBuffer.
     vstmia.32   r0!, {s16 - s31}
-
+#endif
     // Return to caller.
     bx      lr
 


### PR DESCRIPTION
I'm currently [integrating CrashCatcher and CrashDebug into modm](https://github.com/modm-io/modm/pull/210) and I'm compiling this for the ARMv6-M, ARMv7-M and ARMv7E-M architectures.

The ARMv7-M Thumb2 instruction set does not have any FPU instructions so the assembler is unable to compile for ARM Cortex-M3 devices.

I used the [predefined architecture macros from GCC](http://micro-os-plus.sourceforge.net/wiki/Predefined_macros) to disable the FPU registers, but it's an ugly solution.
Is there a reason why you're dynamically checking for `isARMv6MDevice()`? This is definitely known at compile time and you even provide different static libraries for this anyways.

cc @adamgreen 