### PR TITLE
Add possibility to get access to internal instance of Object

### DIFF
--- a/Core/mocks/DumpMocks.c
+++ b/Core/mocks/DumpMocks.c
@@ -128,7 +128,7 @@ void CrashCatcher_DumpStart(const CrashCatcherInfo* pInfo)
 {
     g_dumpStartCallCount++;
     if (g_dumpStartSimulateStackOverflow)
-        g_crashCatcherStack[0] = 0;
+        g_crashCatcherStack[1] = 0;
     memcpy(&g_dumpInfo, pInfo, sizeof(g_dumpInfo));
 }
 

--- a/Core/src/CrashCatcherPriv.h
+++ b/Core/src/CrashCatcherPriv.h
@@ -19,7 +19,7 @@
 
 /* Definitions used by assembly language and C code. */
 #if !defined(CRASH_CATCHER_STACK_WORD_COUNT)
-#define CRASH_CATCHER_STACK_WORD_COUNT 125
+#define CRASH_CATCHER_STACK_WORD_COUNT 126
 #endif
 
 /* Does this device support THUMB instructions for FPU access? */
@@ -84,6 +84,14 @@ typedef struct
     uint32_t exceptionLR;
 } CrashCatcherExceptionRegisters;
 
+/* This structure contains the internals with private data, only to be accessed by custom handlers. */
+typedef struct
+{
+    const CrashCatcherExceptionRegisters* pExceptionRegisters;
+    CrashCatcherStackedRegisters*         pSP;
+    uint32_t                              flags;
+    CrashCatcherInfo                      info;
+} CrashCatcherPrivObject;
 
 /* This is the area of memory that would normally be used for the stack when running on an actual Cortex-M
    processor.  Unit tests can write to this buffer to simulate stack overflow. */
@@ -100,6 +108,9 @@ void CrashCatcher_CopyAllFloatingPointRegisters(uint32_t* pBuffer);
 /* Called from CrashCatcher core to copy upper 16 floating point registers to supplied buffer. The supplied buffer must be
    large enough to contain 16 32-bit values (S16-S31). */
 void CrashCatcher_CopyUpperFloatingPointRegisters(uint32_t* pBuffer);
+
+/* Singleton access to current CrashCatcher private object instance, only to be accessed by custom handlers. */
+const CrashCatcherPrivObject* CrashCatcher_GetPrivInstance(void);
 
 #endif // #if !defined(__ASSEMBLER__) || (!__ASSEMBLER__)
 

--- a/Core/tests/DumpMocksTests.cpp
+++ b/Core/tests/DumpMocksTests.cpp
@@ -219,15 +219,15 @@ TEST(DumpMocks, GetRamRegions_SetToReturnValidPointer_Verify)
 
 TEST(DumpMocks, EnableDumpStartStackOverflowSimulation_ValidateStackModified)
 {
-    g_crashCatcherStack[0] = CRASH_CATCHER_STACK_SENTINEL;
+    g_crashCatcherStack[1] = CRASH_CATCHER_STACK_SENTINEL;
     DumpMocks_EnableDumpStartStackOverflowSimulation();
     CrashCatcher_DumpStart(&m_dummyInfo);
-    CHECK_EQUAL(0x00000000, g_crashCatcherStack[0]);
+    CHECK_EQUAL(0x00000000, g_crashCatcherStack[1]);
 }
 
 TEST(DumpMocks, EnableDumpStartStackOverflowSimulation_ValidateDefaultsToNoModification)
 {
-    g_crashCatcherStack[0] = CRASH_CATCHER_STACK_SENTINEL;
+    g_crashCatcherStack[1] = CRASH_CATCHER_STACK_SENTINEL;
     CrashCatcher_DumpStart(&m_dummyInfo);
-    CHECK_EQUAL(CRASH_CATCHER_STACK_SENTINEL, g_crashCatcherStack[0]);
+    CHECK_EQUAL(CRASH_CATCHER_STACK_SENTINEL, g_crashCatcherStack[1]);
 }


### PR DESCRIPTION
Currently the CrashCatcher is rather tightly coupled with CrashDebug, and this patch tries to decouple them to some extent, to be able to write more stand-alone utils for parsing debug output from CrashCatcher. The customer handler would eg need access to registers and do not want to store CrashCatcher internal states.