### PR TITLE
Use HFSR to determine isBKPT on ARMv7

### DIFF
--- a/Core/src/CrashCatcher.c
+++ b/Core/src/CrashCatcher.c
@@ -20,11 +20,11 @@
 /* Test harness will define this value on 64-bit machine to provide upper 32-bits of pointer addresses. */
 CRASH_CATCHER_TEST_WRITEABLE uint64_t g_crashCatcherTestBaseAddress;
 
-/* The unit tests can point the core to a fake location for the SCB->CPUID register. */
-CRASH_CATCHER_TEST_WRITEABLE uint32_t* g_pCrashCatcherCpuId = (uint32_t*)0xE000ED00;
+/* The unit tests can fake ARM v6/v7. */
+CRASH_CATCHER_TEST_WRITEABLE uint32_t g_CrashCatcherARMv7 = CRASH_CATCHER_ARMV7;
 
 /* The unit tests can point the core to a fake location for the fault status registers. */
-CRASH_CATCHER_TEST_WRITEABLE uint32_t* g_pCrashCatcherFaultStatusRegisters = (uint32_t*)0xE000ED28;
+CRASH_CATCHER_TEST_WRITEABLE FaultStatusRegisters* g_pCrashCatcherFaultStatusRegisters = (FaultStatusRegisters*)0xE000ED28;
 
 /* The unit tests can point the core to a fake location for the Coprocessor Access Control Register. */
 CRASH_CATCHER_TEST_WRITEABLE uint32_t* g_pCrashCatcherCoprocessorAccessControlRegister = (uint32_t*)0xE000ED88;
@@ -66,7 +66,6 @@ static void dumpMSPandPSPandExceptionPSR(const Object* pObject);
 static void dumpFloatingPointRegisters(const Object* pObject);
 static void dumpMemoryRegions(const CrashCatcherMemoryRegion* pRegion);
 static void checkStackSentinelForStackOverflow(void);
-static int isARMv6MDevice(void);
 static void dumpFaultStatusRegisters(void);
 static void advanceProgramCounterPastHardcodedBreakpoint(const Object* pObject);
 
@@ -93,7 +92,7 @@ void CrashCatcher_Entry(const CrashCatcherExceptionRegisters* pExceptionRegister
         if (object.flags & CRASH_CATCHER_FLAGS_FLOATING_POINT)
             dumpFloatingPointRegisters(&object);
         dumpMemoryRegions(CrashCatcher_GetMemoryRegions());
-        if (!isARMv6MDevice())
+        if (g_CrashCatcherARMv7)
             dumpFaultStatusRegisters();
         checkStackSentinelForStackOverflow();
     }
@@ -160,9 +159,17 @@ static int areFloatingPointCoprocessorsEnabled(void)
 
 static void initIsBKPT(Object* pObject)
 {
-    const uint16_t* pInstruction = uint32AddressToPointer(pObject->pSP->pc);
+    if (g_CrashCatcherARMv7)
+    {
+        // DEBUGEVT flag
+        pObject->info.isBKPT = (g_pCrashCatcherFaultStatusRegisters->HFSR & 0x80000000) == 0x80000000;
+    }
+    else
+    {
+        const uint16_t* pInstruction = uint32AddressToPointer(pObject->pSP->pc);
 
-    pObject->info.isBKPT = isBKPT(*pInstruction);
+        pObject->info.isBKPT = isBKPT(*pInstruction);
+    }
 }
 
 static int isBKPT(uint16_t instruction)
@@ -259,20 +266,11 @@ static void checkStackSentinelForStackOverflow(void)
     }
 }
 
-static int isARMv6MDevice(void)
-{
-    static const uint32_t armv6mArchitecture = 0xC << 16;
-    uint32_t              cpuId = *g_pCrashCatcherCpuId;
-    uint32_t              architecture = cpuId & (0xF << 16);
-
-    return (architecture == armv6mArchitecture);
-}
-
 static void dumpFaultStatusRegisters(void)
 {
     uint32_t                 faultStatusRegistersAddress = (uint32_t)(unsigned long)g_pCrashCatcherFaultStatusRegisters;
     CrashCatcherMemoryRegion faultStatusRegion[] = { {faultStatusRegistersAddress,
-                                                      faultStatusRegistersAddress + 5 * sizeof(uint32_t),
+                                                      faultStatusRegistersAddress + sizeof(FaultStatusRegisters),
                                                       CRASH_CATCHER_WORD},
                                                      {0xFFFFFFFF, 0xFFFFFFFF, CRASH_CATCHER_BYTE} };
     dumpMemoryRegions(faultStatusRegion);

--- a/Core/src/CrashCatcherPriv.h
+++ b/Core/src/CrashCatcherPriv.h
@@ -23,10 +23,16 @@
 #endif
 
 /* Does this device support THUMB instructions for FPU access? */
-#ifdef __ARM_ARCH_7EM__
+#ifdef __FPU_USED
 #define CRASH_CATCHER_WITH_FPU 1
 #else
 #define CRASH_CATCHER_WITH_FPU 0
+#endif
+
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+#define CRASH_CATCHER_ARMV7 1
+#else
+#define CRASH_CATCHER_ARMV7 0
 #endif
 
 
@@ -83,6 +89,16 @@ typedef struct
     uint32_t r11;
     uint32_t exceptionLR;
 } CrashCatcherExceptionRegisters;
+
+
+typedef struct
+{
+    uint32_t CFSR;  /* Configurable Fault Status Register */
+    uint32_t HFSR;  /* HardFault Status Register */
+    uint32_t DFSR;  /* Debug Fault Status Register */
+    uint32_t MMFAR; /* MemManage Fault Address Register */
+    uint32_t BFAR;  /* BusFault Address Register */
+} FaultStatusRegisters;
 
 
 /* This is the area of memory that would normally be used for the stack when running on an actual Cortex-M

--- a/HexDump/tests/HexDumpTests.cpp
+++ b/HexDump/tests/HexDumpTests.cpp
@@ -34,8 +34,8 @@ extern "C"
     // to exit and not infinite loop.
     extern CrashCatcherReturnCodes g_crashCatcherDumpEndReturn;
 
-    // The unit tests can point the core to a fake location for the SCB->CPUID register.
-    extern uint32_t* g_pCrashCatcherCpuId;
+    // The unit tests can fake ARM v6/v7.
+    extern uint32_t g_CrashCatcherARMv7;
 
     // The unit tests can point the core to a fake location for the fault status registers.
     extern uint32_t* g_pCrashCatcherFaultStatusRegisters;
@@ -59,8 +59,7 @@ TEST_GROUP(CrashCatcher)
     uint32_t                       m_emulatedPSP[8];
     uint32_t                       m_emulatedMSP[8];
     uint16_t                       m_emulatedInstruction;
-    uint32_t                       m_emulatedCpuId;
-    uint32_t                       m_emulatedFaultStatusRegisters[5];
+    FaultStatusRegisters           m_emulatedFaultStatusRegisters;
     uint32_t                       m_emulatedCoprocessorAccessControlRegister;
     uint32_t                       m_expectedSP;
     uint32_t                       m_memoryStart;
@@ -77,7 +76,7 @@ TEST_GROUP(CrashCatcher)
         initMSP();
         emulateNOP();
         initMemory();
-        initCpuId();
+        initArch();
         initFaultStatusRegisters();
         initFloatingPoint();
         if (sizeof(int*) == sizeof(uint64_t))
@@ -147,17 +146,15 @@ TEST_GROUP(CrashCatcher)
         m_memoryStart = (uint32_t)(unsigned long)m_memory;
     }
 
-    void initCpuId()
+    void initArch()
     {
-        static const uint32_t cpuIdCortexM0 = 0x410CC200;
-        m_emulatedCpuId = cpuIdCortexM0;
-        g_pCrashCatcherCpuId = &m_emulatedCpuId;
+        g_CrashCatcherARMv7 = 0;
     }
 
     void initFaultStatusRegisters()
     {
-        memset(m_emulatedFaultStatusRegisters, 0, sizeof(m_emulatedFaultStatusRegisters));
-        g_pCrashCatcherFaultStatusRegisters = m_emulatedFaultStatusRegisters;
+        memset(&m_emulatedFaultStatusRegisters, 0, sizeof(m_emulatedFaultStatusRegisters));
+        g_pCrashCatcherFaultStatusRegisters = &m_emulatedFaultStatusRegisters;
     }
 
     void initFloatingPoint()


### PR DESCRIPTION
While integrating this fantastic library into a project, I discovered an interesting bug.
I forced a crash by calling a member function on a null pointer, which of course triggered a bus fault. However, it would then lockup in `initIsBKPT()`. Since the PC itself was invalid, trying to dereference it to examine the instruction caused a double-fault.

After some digging, I found that the DEBUGEVT flag in the HFSR could serve as a BKPT indicator.

Unfortunately, ARMv6 has no access to debug registers. Without a good way to determine if an address is valid ahead of time, I opted to leave the v6 BKPT detection alone. So v6 is no worse off than before, but v7 should benefit.

Lastly, this also switches from runtime to compile-time arch detection.
As the runtime check was only used to determine whether to print the fault status registers, I don't see any issue with this.
But if there was a particular reason you needed to use the CPUID I could put it back.